### PR TITLE
Integration ready

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in giraph.gemspec
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: [:spec]

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "giraph"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+require "pry"
+Pry.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/giraph.gemspec
+++ b/giraph.gemspec
@@ -1,0 +1,32 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'giraph/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'giraph'
+  spec.version       = Giraph::VERSION
+  spec.authors       = ['Erman Celen']
+  spec.email         = ['erman@upserve.com']
+
+  spec.summary       = 'Composable GraphQL for micro-services'
+  spec.description   = 'Expose a remote GraphQL endpoint within another as a regular field'
+  spec.homepage      = 'https://github.com/upserve/giraph'
+  spec.license       = 'MIT'
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir        = 'bin'
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ['lib']
+
+  spec.required_ruby_version = '~> 2.1'
+
+  spec.add_runtime_dependency 'graphql', '~> 0.15.3'
+
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+end

--- a/giraph.gemspec
+++ b/giraph.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'graphql', '~> 0.15.3'
+  spec.add_runtime_dependency 'graphql', '0.15.3'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'pry'

--- a/lib/giraph.rb
+++ b/lib/giraph.rb
@@ -1,0 +1,13 @@
+require 'json'
+require 'graphql'
+
+require 'giraph/version'
+
+require 'giraph/subquery'
+require 'giraph/extensions/field'
+require 'giraph/remote/response'
+require 'giraph/remote/connector'
+require 'giraph/remote/query'
+require 'giraph/remote/mutation'
+require 'giraph/resolver'
+require 'giraph/schema'

--- a/lib/giraph/extensions/field.rb
+++ b/lib/giraph/extensions/field.rb
@@ -1,0 +1,33 @@
+module Giraph
+  # Wrapped methods on GraphQL::Field class
+  module Extensions
+    module Field
+      # Wrap the 'resolve' method on Field so that we can
+      # intercept the registered resolution Proc and resolve
+      # on already-resolved values from the JSON returned
+      # to the sub-query through the remote endpoint
+      def resolve(object, arguments, context)
+        # Giraph always parses a remote response with a special Hash
+        # class called 'Giraph::Remote::Response', which is a no-op sub-class
+        # of Hash. This way we can easily recognize this special
+        # "resolve on already resolved response" case while still
+        # allowing regular Hash to be resolved normally.
+        if object.instance_of? Giraph::Remote::Response
+          # If the field was aliased, response will be keyed by the alias
+          field = context.ast_node.alias || context.ast_node.name
+          object[field.to_sym]
+        else
+          # Not Giraph, let it through...
+          super
+        end
+      end
+    end
+  end
+end
+
+# Monkey-patch GraphQL Field class to wrap the default 'resolve'
+module GraphQL
+  class Field
+    prepend Giraph::Extensions::Field
+  end
+end

--- a/lib/giraph/remote/connector.rb
+++ b/lib/giraph/remote/connector.rb
@@ -19,13 +19,13 @@ module Giraph
         query = "#{query_type} #{subquery.subquery_string}"
 
         # Variable hash to send along
-        variable = subquery.variable_string do |dict|
+        variables = subquery.variable_string do |dict|
           dict.merge(__giraph_root__: remote_root)
         end
 
         # Remote can return data, error or totally freak out,
         # we handle all here, and note anything of relevance
-        return_data_or_raise(run_query(query, variable)) do |exception|
+        return_data_or_raise(run_query(query, variables)) do |exception|
           # Tack on details for host's version of the query
           exception.ast_node = context.ast_node
         end

--- a/lib/giraph/remote/connector.rb
+++ b/lib/giraph/remote/connector.rb
@@ -42,7 +42,7 @@ module Giraph
       end
 
       def return_data_or_raise(response, &block)
-        result = to_giraph_json(response.body)
+        result = Remote::Response.from_json(response.body)
 
         # Remote returned a valid result set, pass it through
         return result[:data] if result[:data]
@@ -63,17 +63,6 @@ module Giraph
           # Allow exception to be modified if needed
           block.call(ex) if block
         end
-      end
-
-      # We specifically parse JSON using Giraph::Remote::Response
-      # in place of regular Hash so that downstreams can realize
-      # that this is a Giraph-sourced remote response.
-      def to_giraph_json(raw_json)
-        JSON.parse(
-          raw_json,
-          symbolize_names: true,
-          object_class: Remote::Response
-        )
       end
     end
   end

--- a/lib/giraph/remote/connector.rb
+++ b/lib/giraph/remote/connector.rb
@@ -1,0 +1,80 @@
+module Giraph
+  module Remote
+    class InvalidResponse < StandardError; end
+
+    # Reconstructs a valid GraphQL root-query from the current
+    # field in question, including all variables and params,
+    # sends the query request and parses the response.
+    class Connector
+      def initialize(endpoint, mutation: false)
+        @endpoint = endpoint
+        @mutation = mutation
+      end
+
+      # The resolver method for the connection field.
+      def resolve(context, remote_root: {})
+        subquery = Subquery.new(context)
+
+        # Full GraphQL query for remote
+        query = "#{query_type} #{subquery.subquery_string}"
+
+        # Variable hash to send along
+        variable = subquery.variable_string do |dict|
+          dict.merge(__giraph_root__: remote_root)
+        end
+
+        # Remote can return data, error or totally freak out,
+        # we handle all here, and note anything of relevance
+        return_data_or_raise(run_query(query, variable)) do |exception|
+          # Tack on details for host's version of the query
+          exception.ast_node = context.ast_node
+        end
+      end
+
+      private
+
+      def query_type
+        @mutation ? 'mutation' : 'query'
+      end
+
+      def run_query(query, variable)
+        Net::HTTP.post_form(URI(@endpoint), query: query, variables: variable)
+      end
+
+      def return_data_or_raise(response, &block)
+        result = to_giraph_json(response.body)
+
+        # Remote returned a valid result set, pass it through
+        return result[:data] if result[:data]
+
+        # Remote returned a GraphQL error, raise it as such
+        raise remote_execution_error(result[:errors], block)
+      rescue JSON::ParserError
+        # Remote server returned an invalid result (non-JSON response)
+        # meaning something went wrong. Raise an error that reflects this.
+        raise(
+          InvalidResponse,
+          "Remote endpoint returned: '#{response.code} #{response.msg}'"
+        )
+      end
+
+      def remote_execution_error(errors, block)
+        GraphQL::ExecutionError.new(errors).tap do |ex|
+          # Allow exception to be modified if needed
+          block.call(ex) if block
+        end
+      end
+
+      # We specifically parse JSON using Giraph::Remote::Response
+      # in place of regular Hash so that downstreams can realize
+      # that this is a Giraph-sourced remote response.
+      def to_giraph_json(raw_json)
+        JSON.parse(
+          raw_json,
+          symbolize_names: true,
+          object_class: Remote::Response
+        )
+      end
+    end
+  end
+end

--- a/lib/giraph/remote/connector.rb
+++ b/lib/giraph/remote/connector.rb
@@ -2,13 +2,10 @@ module Giraph
   module Remote
     class InvalidResponse < StandardError; end
 
-    # Reconstructs a valid GraphQL root-query from the current
-    # field in question, including all variables and params,
-    # sends the query request and parses the response.
+    # sends the reconstructed subquery request and parses the response.
     class Connector
-      def initialize(endpoint, mutation: false)
+      def initialize(endpoint)
         @endpoint = endpoint
-        @mutation = mutation
       end
 
       # The resolver method for the connection field.

--- a/lib/giraph/remote/mutation.rb
+++ b/lib/giraph/remote/mutation.rb
@@ -9,6 +9,12 @@ module Giraph
           &block
         )
       end
+
+      private
+
+      def query_type
+        'mutation'
+      end
     end
   end
 end

--- a/lib/giraph/remote/mutation.rb
+++ b/lib/giraph/remote/mutation.rb
@@ -1,0 +1,12 @@
+module Giraph
+  module Remote
+    # Field resolver to plug a remote GraphQL mutation root into a local type
+    class Mutation < Query
+      def initialize(*args)
+        super
+        # Override the mutation flag, rest is the same
+        @mutation = true
+      end
+    end
+  end
+end

--- a/lib/giraph/remote/mutation.rb
+++ b/lib/giraph/remote/mutation.rb
@@ -2,10 +2,12 @@ module Giraph
   module Remote
     # Field resolver to plug a remote GraphQL mutation root into a local type
     class Mutation < Query
-      def initialize(*args)
-        super
-        # Override the mutation flag, rest is the same
-        @mutation = true
+      def self.bind(endpoint, &block)
+        new(
+          endpoint,
+          Remote::Connector.new(endpoint, mutation: true),
+          &block
+        )
       end
     end
   end

--- a/lib/giraph/remote/query.rb
+++ b/lib/giraph/remote/query.rb
@@ -20,11 +20,33 @@ module Giraph
         # Given an evaluator block, continue if only it evaluates to non-nil!
         return unless (remote_root = @evaluator.call(obj, args, ctx))
 
+        subquery = Subquery.new(ctx)
+
         # Continue with remote query execution
-        connector.resolve(ctx, remote_root: remote_root.to_h)
+        connector.resolve(
+          ctx,
+          query_string(subquery),
+          query_variables(subquery, remote_root)
+        )
       end
 
       private
+
+      def query_type
+        'query'
+      end
+
+      def query_string(subquery)
+        # Full GraphQL query for remote
+        "#{query_type} #{subquery.subquery_string}"
+      end
+
+      def query_variables(subquery, remote_root)
+        # Variable hash to send along
+        subquery.variable_string do |dict|
+          dict.merge(__giraph_root__: remote_root)
+        end
+      end
 
       def default_evaluator(*args)
         {}

--- a/lib/giraph/remote/query.rb
+++ b/lib/giraph/remote/query.rb
@@ -5,7 +5,7 @@ module Giraph
       def self.bind(endpoint, &block)
         new(
           endpoint,
-          Remote::Connector.new(endpoint, mutation: false),
+          Remote::Connector.new(endpoint),
           &block
         )
       end
@@ -16,6 +16,9 @@ module Giraph
         @connector = connector
       end
 
+      # Reconstructs a valid GraphQL root-query from the current
+      # field in question, including all variables and params,
+      # hands over to connector to execute remotely.
       def call(obj, args, ctx)
         # Given an evaluator block, continue if only it evaluates to non-nil!
         return unless (remote_root = @evaluator.call(obj, args, ctx))
@@ -52,7 +55,7 @@ module Giraph
         {}
       end
 
-      attr_reader :endpoint, :mutation, :connector
+      attr_reader :endpoint, :connector
     end
   end
 end

--- a/lib/giraph/remote/query.rb
+++ b/lib/giraph/remote/query.rb
@@ -1,0 +1,33 @@
+module Giraph
+  module Remote
+    # Field resolver to plug a remote GraphQL query root into a local type
+    class Query
+      def initialize(endpoint, &block)
+        @endpoint = endpoint
+        @evaluator = block || method(:default_evaluator)
+        # Default is a query, can be overriden by sub-classes
+        @mutation = false
+      end
+
+      def call(obj, args, ctx)
+        # Given an evaluator block, continue if only it evaluates to non-nil!
+        return unless (remote_root = @evaluator.call(obj, args, ctx))
+
+        # Continue with remote query execution
+        connector.resolve(ctx, remote_root: remote_root.to_h)
+      end
+
+      private
+
+      def connector
+        @connector ||= Remote::Connector.new(endpoint, mutation: mutation)
+      end
+
+      def default_evaluator(*args)
+        {}
+      end
+
+      attr_reader :endpoint, :mutation
+    end
+  end
+end

--- a/lib/giraph/remote/query.rb
+++ b/lib/giraph/remote/query.rb
@@ -2,11 +2,18 @@ module Giraph
   module Remote
     # Field resolver to plug a remote GraphQL query root into a local type
     class Query
-      def initialize(endpoint, &block)
+      def self.bind(endpoint, &block)
+        new(
+          endpoint,
+          Remote::Connector.new(endpoint, mutation: false),
+          &block
+        )
+      end
+
+      def initialize(endpoint, connector, &block)
         @endpoint = endpoint
         @evaluator = block || method(:default_evaluator)
-        # Default is a query, can be overriden by sub-classes
-        @mutation = false
+        @connector = connector
       end
 
       def call(obj, args, ctx)
@@ -19,15 +26,11 @@ module Giraph
 
       private
 
-      def connector
-        @connector ||= Remote::Connector.new(endpoint, mutation: mutation)
-      end
-
       def default_evaluator(*args)
         {}
       end
 
-      attr_reader :endpoint, :mutation
+      attr_reader :endpoint, :mutation, :connector
     end
   end
 end

--- a/lib/giraph/remote/response.rb
+++ b/lib/giraph/remote/response.rb
@@ -1,0 +1,9 @@
+module Giraph
+  module Remote
+    # Dummy Hash-wrapper to enable precise `instance_of?` checks
+    # Allows us to differentiate JSON responses that are
+    # coming from remote GraphQL interface vs regular Hash objects
+    class Response < Hash
+    end
+  end
+end

--- a/lib/giraph/remote/response.rb
+++ b/lib/giraph/remote/response.rb
@@ -3,7 +3,12 @@ module Giraph
     # Dummy Hash-wrapper to enable precise `instance_of?` checks
     # Allows us to differentiate JSON responses that are
     # coming from remote GraphQL interface vs regular Hash objects
+    # including all nested hashes within a response.
     class Response < Hash
+      # Factory method to encapsulate special parsing logic
+      def self.from_json(raw_json)
+        JSON.parse(raw_json, symbolize_names: true, object_class: self)
+      end
     end
   end
 end

--- a/lib/giraph/resolver.rb
+++ b/lib/giraph/resolver.rb
@@ -1,0 +1,27 @@
+module Giraph
+  # Proc-like class to allow declerative links to external
+  # resolution handlers (so the "definition" gem can stay pure resolution-wise)
+  class Resolver
+    class UnknownOperation < StandardError; end
+
+    def initialize(resolver_method)
+      @resolver_method = resolver_method
+    end
+
+    # Resolves the field by calling the previously given method
+    # on the registered Resolver object for the current operation
+    # type (currently query or mutation)
+    def call(obj, args, ctx)
+      # Find out operation type (query, mutation, etc.)
+      op_type = ctx.query.selected_operation.operation_type.to_sym
+
+      # Ensure there is a registered resolver for it
+      unless (resolver = ctx[:__giraph_resolver__][op_type])
+        raise UnknownOperation, "No resolver found for '#{op_type}' op type"
+      end
+
+      # Call the requested method on resolver
+      resolver.send(@resolver_method, obj, args, ctx)
+    end
+  end
+end

--- a/lib/giraph/resolver.rb
+++ b/lib/giraph/resolver.rb
@@ -4,8 +4,12 @@ module Giraph
   class Resolver
     class UnknownOperation < StandardError; end
 
-    def initialize(resolver_method)
-      @resolver_method = resolver_method
+    def self.for(method_name)
+      new(method_name)
+    end
+
+    def initialize(method_name)
+      @method_name = method_name
     end
 
     # Resolves the field by calling the previously given method
@@ -21,7 +25,7 @@ module Giraph
       end
 
       # Call the requested method on resolver
-      resolver.send(@resolver_method, obj, args, ctx)
+      resolver.send(@method_name, obj, args, ctx)
     end
   end
 end

--- a/lib/giraph/resolver.rb
+++ b/lib/giraph/resolver.rb
@@ -25,7 +25,7 @@ module Giraph
       end
 
       # Call the requested method on resolver
-      resolver.send(@method_name, obj, args, ctx)
+      resolver.public_send(@method_name, obj, args, ctx)
     end
   end
 end

--- a/lib/giraph/schema.rb
+++ b/lib/giraph/schema.rb
@@ -1,0 +1,46 @@
+module Giraph
+  # GraphQL::Schema wrapper allowing decleration of
+  # resolver objects per op type (query or mutation)
+  class Schema < GraphQL::Schema
+    # Extract special arguments for resolver objects,
+    # let the rest pass-through
+    def initialize(**args)
+      @query_resolver = args.delete(:query_resolver)
+      @mutation_resolver = args.delete(:mutation_resolver)
+      super
+    end
+
+    # Defer the execution only after setting up
+    # context and root_value with resolvers and remote arguments
+    def execute(query, **args)
+      args = args
+             .merge(with_giraph_root(args))
+             .merge(with_giraph_resolvers(args))
+
+      super(query, **args)
+    end
+
+    def with_giraph_root(args)
+      # Extract & remove the special __giraph_root__ key
+      # from variables passed in, if any
+      vars = args[:variables] || {}
+      root = vars.delete('__giraph_root__') || {}
+
+      # Set given pseudo-root as root_value for the execution
+      { root_value: root }
+    end
+
+    def with_giraph_resolvers(args)
+      # Pass on resolver objects in context
+      # which will then be used by Giraph resolvers
+      # to direct per-field resolution
+      context = args[:context] || {}
+      context[:__giraph_resolver__] = {
+        query: @query_resolver,
+        mutation: @mutation_resolver
+      }
+
+      { context: context }
+    end
+  end
+end

--- a/lib/giraph/schema.rb
+++ b/lib/giraph/schema.rb
@@ -1,13 +1,13 @@
 module Giraph
   # GraphQL::Schema wrapper allowing decleration of
   # resolver objects per op type (query or mutation)
-  class Schema < GraphQL::Schema
+  class Schema < DelegateClass(GraphQL::Schema)
     # Extract special arguments for resolver objects,
     # let the rest pass-through
     def initialize(**args)
       @query_resolver = args.delete(:query_resolver)
       @mutation_resolver = args.delete(:mutation_resolver)
-      super
+      super(GraphQL::Schema.new(**args))
     end
 
     # Defer the execution only after setting up
@@ -19,6 +19,8 @@ module Giraph
 
       super(query, **args)
     end
+
+    private
 
     def with_giraph_root(args)
       # Extract & remove the special __giraph_root__ key

--- a/lib/giraph/subquery.rb
+++ b/lib/giraph/subquery.rb
@@ -1,4 +1,7 @@
 module Giraph
+  # Defines a thin & sane API for the sub-query extraction
+  # from the context provided to resolvers via AST, graphql-ruby API
+  # and a touch of regex.
   class Subquery
     attr_reader :query, :query_string
 

--- a/lib/giraph/subquery.rb
+++ b/lib/giraph/subquery.rb
@@ -44,13 +44,13 @@ module Giraph
     def query_variables
       # Recreates the declared query parameters to be passed on
       # to the remote host.
-      declerations = query
+      declarations = query
                      .selected_operation
                      .variables
                      .select(&method(:variable_used?))
                      .map(&method(:variable_decleration))
 
-      "(#{declerations.join(', ')})" unless declerations.empty?
+      "(#{declarations.join(', ')})" unless declarations.empty?
     end
 
     def variable_used?(variable)

--- a/lib/giraph/subquery.rb
+++ b/lib/giraph/subquery.rb
@@ -1,0 +1,69 @@
+module Giraph
+  class Subquery
+    attr_reader :query, :query_string
+
+    def initialize(context)
+      @context = context
+
+      @query = context.query
+      @query_string = context.ast_node.to_query_string
+    end
+
+    def subquery_string
+      "GiraphQuery #{query_variables} #{query_selections}"
+    end
+
+    def variable_string
+      dict = variable_assignments
+      dict = yield dict if block_given?
+
+      dict.to_json
+    end
+
+    private
+
+    def variable_assignments
+      # This re-encodes and passes on all the variable values
+      # paseed to the original query endpoint
+      query.instance_variable_get('@provided_variables')
+    end
+
+    def query_selections
+      # We get the following from node's sub-query:
+      #   nodeName { field1 { field12 } field2(a: $a) field3 }
+      # we want:
+      #   { field1 { field12 } field2(a: $a) field3 }
+      # as the name of node is local information to parent host
+      # and is no use to the remote host.
+      query_string.sub(/^[^{]+/, '')
+    end
+
+    def query_variables
+      # Recreates the declared query parameters to be passed on
+      # to the remote host.
+      declerations = query
+                     .selected_operation
+                     .variables
+                     .select(&method(:variable_used?))
+                     .map(&method(:variable_decleration))
+
+      "(#{declerations.join(', ')})" unless declerations.empty?
+    end
+
+    def variable_used?(variable)
+      query_string[/\$#{Regexp.quote(variable.name)}\W/]
+    end
+
+    def variable_decleration(variable)
+      "$#{variable.name}: #{variable_type(variable)}"
+    end
+
+    def variable_type(variable)
+      if variable.type.is_a?(GraphQL::Language::Nodes::NonNullType)
+        variable.type.of_type.name + '!'
+      else
+        variable.type.name
+      end
+    end
+  end
+end

--- a/lib/giraph/version.rb
+++ b/lib/giraph/version.rb
@@ -1,0 +1,3 @@
+module Giraph
+  VERSION = "0.1.0"
+end

--- a/spec/giraph/extensions/field_spec.rb
+++ b/spec/giraph/extensions/field_spec.rb
@@ -1,8 +1,73 @@
 require 'spec_helper'
 
 describe Giraph::Extensions::Field do
-  it 'overrides default resolver on GraphQL' do
-    # TODO: Check if the overriding resolver behaves as expected
-    # by resolving fields on a Giraph response
+  class MockResolver; end
+
+  let(:schema) do
+    GraphQL::Schema.new(
+      query: query_root,
+      # mutation: mutation_root
+    )
+  end
+
+  let(:query_root) do
+    GraphQL::ObjectType.define do
+      name 'Query'
+
+      field :test do
+        type types.Int
+        argument :foo, types.String
+        resolve MockResolver
+      end
+    end
+  end
+
+  let(:some_context) do
+    {
+      bar: [1, 2]
+    }
+  end
+
+  let(:query_string) do
+    '{ test(foo: "foo value") }'
+  end
+
+  let(:query_variables) do
+    {}
+  end
+
+  let(:giraph_response) do
+    Giraph::Remote::Response[test: 84]
+  end
+
+  it 'allows assigned resolver to resolve under regular execution' do
+    expect(MockResolver).to receive(:call) do |obj, args, ctx|
+      expect(obj).to eq(nil)
+      expect(args[:foo]).to eq('foo value')
+      expect(ctx[:bar]).to eq([1, 2])
+
+      42
+    end
+
+    resp = schema.execute(
+      query_string,
+      variables: query_variables,
+      context: some_context
+    )
+
+    expect(resp).to eq('data' => { 'test' => 42 })
+  end
+
+  it 'intercepts resolver if object-in-resolution is a Giraph response' do
+    expect(MockResolver).to_not receive(:call)
+
+    resp = schema.execute(
+      query_string,
+      variables: query_variables,
+      context: some_context,
+      root_value: giraph_response
+    )
+
+    expect(resp).to eq('data' => { 'test' => 84 })
   end
 end

--- a/spec/giraph/extensions/field_spec.rb
+++ b/spec/giraph/extensions/field_spec.rb
@@ -1,44 +1,7 @@
 require 'spec_helper'
 
 describe Giraph::Extensions::Field do
-  class MockResolver; end
-
-  let(:schema) do
-    GraphQL::Schema.new(
-      query: query_root,
-      # mutation: mutation_root
-    )
-  end
-
-  let(:query_root) do
-    GraphQL::ObjectType.define do
-      name 'Query'
-
-      field :test do
-        type types.Int
-        argument :foo, types.String
-        resolve MockResolver
-      end
-    end
-  end
-
-  let(:some_context) do
-    {
-      bar: [1, 2]
-    }
-  end
-
-  let(:query_string) do
-    '{ test(foo: "foo value") }'
-  end
-
-  let(:query_variables) do
-    {}
-  end
-
-  let(:giraph_response) do
-    Giraph::Remote::Response[test: 84]
-  end
+  include_context 'sample graphql structure'
 
   it 'allows assigned resolver to resolve under regular execution' do
     expect(MockResolver).to receive(:call) do |obj, args, ctx|
@@ -52,7 +15,7 @@ describe Giraph::Extensions::Field do
     resp = schema.execute(
       query_string,
       variables: query_variables,
-      context: some_context
+      context: query_context
     )
 
     expect(resp).to eq('data' => { 'test' => 42 })
@@ -64,7 +27,7 @@ describe Giraph::Extensions::Field do
     resp = schema.execute(
       query_string,
       variables: query_variables,
-      context: some_context,
+      context: query_context,
       root_value: giraph_response
     )
 

--- a/spec/giraph/extensions/field_spec.rb
+++ b/spec/giraph/extensions/field_spec.rb
@@ -5,11 +5,12 @@ describe Giraph::Extensions::Field do
 
   it 'allows assigned resolver to resolve under regular execution' do
     expect(MockResolver).to receive(:call) do |obj, args, ctx|
-      expect(obj).to eq(nil)
+      expect(obj).to eq({})
       expect(args[:foo]).to eq('foo value')
       expect(ctx[:bar]).to eq([1, 2])
 
-      42
+      # Return a regular object to resolve further
+      Struct.new(:res).new(42)
     end
 
     resp = schema.execute(
@@ -18,19 +19,25 @@ describe Giraph::Extensions::Field do
       context: query_context
     )
 
-    expect(resp).to eq('data' => { 'test' => 42 })
+    expect(resp).to eq('data' => { 'test' => { 'res' => 42 } })
   end
 
   it 'intercepts resolver if object-in-resolution is a Giraph response' do
-    expect(MockResolver).to_not receive(:call)
+    expect(MockResolver).to receive(:call) do |obj, args, ctx|
+      expect(obj).to eq({})
+      expect(args[:foo]).to eq('foo value')
+      expect(ctx[:bar]).to eq([1, 2])
+
+      # Return a Giraph Response object to immitate intercepted remote query
+      Giraph::Remote::Response[res: 84]
+    end
 
     resp = schema.execute(
       query_string,
       variables: query_variables,
-      context: query_context,
-      root_value: giraph_response
+      context: query_context
     )
 
-    expect(resp).to eq('data' => { 'test' => 84 })
+    expect(resp).to eq('data' => { 'test' => { 'res' => 84 } })
   end
 end

--- a/spec/giraph/extensions/field_spec.rb
+++ b/spec/giraph/extensions/field_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Giraph::Extensions::Field do
+  it 'overrides default resolver on GraphQL' do
+    # TODO: Check if the overriding resolver behaves as expected
+    # by resolving fields on a Giraph response
+  end
+end

--- a/spec/giraph/remote/connector_spec.rb
+++ b/spec/giraph/remote/connector_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe Giraph::Remote::Connector do
+  describe '.resolve' do
+    let(:response) do
+      double(
+        Net::HTTPResponse,
+        body: response_body,
+        code: response_code,
+        msg: response_msg
+      )
+    end
+
+    let(:mock_context) { double(GraphQL::Query::Context, ast_node: 'AST_NODE') }
+
+    let(:response_body) { '{ "data": { "foo": { "bar": [1, 2] } } }' }
+    let(:response_code) { 201 }
+    let(:response_msg) { 'Created' }
+
+    let(:query_string) { 'query GiraphQuery($foo: Int) { bar(baz: $foo) }' }
+    let(:query_variables) { '{ "foo": 100 }' }
+
+    subject { described_class.new('some_remote_host') }
+
+    it 'sends over the query, parses the response, returns relevant parts' do
+      expect(Net::HTTP).to receive(:post_form).and_return(response)
+
+      result = subject.resolve(mock_context, query_string, query_variables)
+
+      expect(result).to eq(foo: { bar: [1, 2] })
+    end
+
+    context 'when remote returns GraphQL errors' do
+      let(:response_body) do
+        '{"errors":[{"message":"FOOL!","locations":[{"line":18,"column":9}]}]}'
+      end
+
+      it 'rasises the error for parent as a GraphQL error' do
+        expect(Net::HTTP).to receive(:post_form).and_return(response)
+
+        expect do
+          subject.resolve(mock_context, query_string, query_variables)
+        end.to raise_error(GraphQL::ExecutionError, /FOOL!/)
+      end
+    end
+
+    context 'when remote returns invalid response' do
+      let(:response_body) do
+        '--NOT A JSON--'
+      end
+
+      let(:response_code) { 500 }
+      let(:response_msg) { 'Bad, bad server!' }
+
+      it 'rasises the error for parent as a GraphQL error' do
+        expect(Net::HTTP).to receive(:post_form).and_return(response)
+
+        expect do
+          subject.resolve(mock_context, query_string, query_variables)
+        end.to raise_error(
+          Giraph::Remote::InvalidResponse,
+          "Remote endpoint returned: '500 Bad, bad server!'"
+        )
+      end
+    end
+  end
+end

--- a/spec/giraph/remote/query_spec.rb
+++ b/spec/giraph/remote/query_spec.rb
@@ -10,7 +10,7 @@ describe Giraph::Remote::Query do
   let(:context) { { some: 'context' } }
 
   context 'given an evaluator block' do
-    subject { described_class.new('endpoint', &evaluator) }
+    subject { described_class.new('endpoint', connector, &evaluator) }
 
     let(:evaluator) { -> (o, a, c) { evaluator_response } }
 
@@ -18,11 +18,6 @@ describe Giraph::Remote::Query do
       let(:evaluator_response) { { foo: :bar } }
 
       it 'calls the block before resolving' do
-        expect(Giraph::Remote::Connector)
-          .to receive(:new)
-          .with('endpoint', mutation: false)
-          .and_return(connector)
-
         expect(connector)
           .to receive(:resolve)
           .with({ some: 'context' }, remote_root: { foo: :bar })
@@ -36,7 +31,6 @@ describe Giraph::Remote::Query do
       let(:evaluator_response) { nil }
 
       it 'does not let the request continue' do
-        expect(Giraph::Remote::Connector).to_not receive(:new)
         expect(connector).to_not receive(:resolve)
 
         expect(subject.call(object, args, context)).to_not be
@@ -45,14 +39,9 @@ describe Giraph::Remote::Query do
   end
 
   context 'given no evaluator block' do
-    subject { described_class.new('endpoint') }
+    subject { described_class.new('endpoint', connector) }
 
     it 'calls the default evaluator' do
-      expect(Giraph::Remote::Connector)
-        .to receive(:new)
-        .with('endpoint', mutation: false)
-        .and_return(connector)
-
       expect(connector)
         .to receive(:resolve)
         .with({ some: 'context' }, remote_root: {})

--- a/spec/giraph/remote/query_spec.rb
+++ b/spec/giraph/remote/query_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe Giraph::Remote::Query do
+  include_context 'sample graphql structure'
+
+  let(:connector) { double(Giraph::Remote::Connector) }
+
+  let(:object) { { some: 'object' } }
+  let(:args) { { some: 'args' } }
+  let(:context) { { some: 'context' } }
+
+  context 'given an evaluator block' do
+    subject { described_class.new('endpoint', &evaluator) }
+
+    let(:evaluator) { -> (o, a, c) { evaluator_response } }
+
+    context 'that returns data' do
+      let(:evaluator_response) { { foo: :bar } }
+
+      it 'calls the block before resolving' do
+        expect(Giraph::Remote::Connector)
+          .to receive(:new)
+          .with('endpoint', mutation: false)
+          .and_return(connector)
+
+        expect(connector)
+          .to receive(:resolve)
+          .with({ some: 'context' }, remote_root: { foo: :bar })
+          .and_return(good: 'data')
+
+        expect(subject.call(object, args, context)).to eq(good: 'data')
+      end
+    end
+
+    context 'that returns falsy' do
+      let(:evaluator_response) { nil }
+
+      it 'does not let the request continue' do
+        expect(Giraph::Remote::Connector).to_not receive(:new)
+        expect(connector).to_not receive(:resolve)
+
+        expect(subject.call(object, args, context)).to_not be
+      end
+    end
+  end
+
+  context 'given no evaluator block' do
+    subject { described_class.new('endpoint') }
+
+    it 'calls the default evaluator' do
+      expect(Giraph::Remote::Connector)
+        .to receive(:new)
+        .with('endpoint', mutation: false)
+        .and_return(connector)
+
+      expect(connector)
+        .to receive(:resolve)
+        .with({ some: 'context' }, remote_root: {})
+        .and_return(good: 'data')
+
+      expect(subject.call(object, args, context)).to eq(good: 'data')
+    end
+  end
+end

--- a/spec/giraph/remote/response_spec.rb
+++ b/spec/giraph/remote/response_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Giraph::Remote::Response do
-  describe '#from_json' do
+  describe '.from_json' do
     let(:sample_json) do
       {
         answer: 42,

--- a/spec/giraph/remote/response_spec.rb
+++ b/spec/giraph/remote/response_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Giraph::Remote::Response do
+  describe '#from_json' do
+    let(:sample_json) do
+      {
+        answer: 42,
+        from: {
+          type: 'computer',
+          name: 'Deep Thought'
+        },
+        to: 'Ultimate question of...',
+        what: [
+          {
+            question: 'Life'
+          },
+          {
+            prefix: 'the',
+            question: 'Universe'
+          },
+          {
+            question: 'Everything'
+          }
+        ]
+      }
+    end
+
+    let(:test_input) { sample_json.to_json }
+    let(:expected_output) { sample_json }
+
+    it 'parses JSON using Response hashes recursively' do
+      # This is to allow each resolver down stream to
+      # recognize a remote GraphQL response and act accordingly.
+
+      result = described_class.from_json(test_input)
+
+      expect(result).to eq(expected_output)
+
+      expect(result).to be_instance_of(described_class)
+      expect(result[:from]).to be_instance_of(described_class)
+      result[:what].each do |rec|
+        expect(rec).to be_instance_of(described_class)
+      end
+
+      expect(result[:answer]).to_not be_instance_of(described_class)
+      expect(result[:to]).to_not be_instance_of(described_class)
+      expect(result[:what]).to_not be_instance_of(described_class)
+    end
+  end
+end

--- a/spec/giraph/resolver_spec.rb
+++ b/spec/giraph/resolver_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Giraph::Resolver do
+  include_context 'sample graphql structure'
+
+  let(:query_string) do
+    'query Test($baz: String) { proxy(foo: $baz) { res } }'
+  end
+
+  it 'calls requested method on given resolver object at resolution time' do
+    expect(query_resolver).to receive(:resolver_method) do |obj, args, ctx|
+      expect(obj).to eq({})
+      expect(args[:foo]).to eq('foo value')
+      expect(ctx[:bar]).to eq([1, 2])
+
+      Struct.new(:res).new(126)
+    end
+
+    resp = schema.execute(
+      query_string,
+      variables: query_variables,
+      context: query_context
+    )
+
+    expect(resp).to eq('data' => { 'proxy' => { 'res' => 126 } })
+  end
+end

--- a/spec/giraph/resolver_spec.rb
+++ b/spec/giraph/resolver_spec.rb
@@ -24,4 +24,43 @@ describe Giraph::Resolver do
 
     expect(resp).to eq('data' => { 'proxy' => { 'res' => 126 } })
   end
+
+  context 'for a mutation query' do
+    let(:mutation_string) do
+      %(
+        mutation Test($baz: String) {
+          proxy(foo: $baz) {
+            update(input: {foo: $baz, bar: 21})
+          }
+        }
+      )
+    end
+
+    it 'calls requested method on given resolver object at resolution time' do
+      expect(mutation_resolver).to receive(:resolver_method) do |obj, args, ctx|
+        expect(obj).to eq({})
+        expect(args[:foo]).to eq('foo value')
+        expect(ctx[:bar]).to eq([1, 2])
+
+        { le: 'cola' }
+      end
+
+      expect(mutation_resolver).to receive(:update) do |obj, args, ctx|
+        expect(obj).to eq(le: 'cola')
+        expect(args[:input][:foo]).to eq('foo value')
+        expect(args[:input][:bar]).to eq(21)
+        expect(ctx[:bar]).to eq([1, 2])
+
+        42
+      end
+
+      resp = schema.execute(
+        mutation_string,
+        variables: query_variables,
+        context: query_context
+      )
+
+      expect(resp).to eq('data' => { 'proxy' => { 'update' => 42 } })
+    end
+  end
 end

--- a/spec/giraph/schema_spec.rb
+++ b/spec/giraph/schema_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Giraph::Schema do
+  include_context 'sample graphql structure'
+
+  it 'sets root_value to empty hash by default' do
+    expect(MockResolver).to receive(:call) do |obj, args, ctx|
+      expect(obj).to eq({})
+      expect(args[:foo]).to eq('foo value')
+      expect(ctx[:bar]).to eq([1, 2])
+
+      Struct.new(:res).new(126)
+    end
+
+    resp = schema.execute(
+      query_string,
+      variables: query_variables,
+      context: query_context
+    )
+
+    expect(resp).to eq('data' => { 'test' => { 'res' => 126 } })
+  end
+
+  context 'given Giraph root value from remote parent' do
+    let(:query_variables) do
+      {
+        'baz' => 'foo value',
+        '__giraph_root__' => {
+          'hello' => 'world',
+          'what?' => {
+            'answer' => 42,
+            'for' => ['question', 10.3]
+          }
+        }
+      }
+    end
+
+    it 'sets the Giraph root from parent as root_value' do
+      expect(MockResolver).to receive(:call) do |obj, args, ctx|
+        expect(obj).to eq(
+          'hello' => 'world',
+          'what?' => {
+            'answer' => 42,
+            'for' => ['question', 10.3]
+          }
+        )
+        expect(args[:foo]).to eq('foo value')
+        expect(ctx[:bar]).to eq([1, 2])
+
+        Struct.new(:res).new(126)
+      end
+
+      resp = schema.execute(
+        query_string,
+        variables: query_variables,
+        context: query_context
+      )
+
+      expect(resp).to eq('data' => { 'test' => { 'res' => 126 } })
+    end
+  end
+end

--- a/spec/giraph/subquery_spec.rb
+++ b/spec/giraph/subquery_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+describe Giraph::Subquery do
+  include_context 'sample graphql structure'
+
+  context 'given a valid query' do
+    let(:query_string) do
+      %(
+        query Test($baz: String, $bazzz: String!) {
+          remote {
+            argd(arg1: $bazzz)
+          }
+
+          proxy(foo: $baz) {
+            res
+          }
+        }
+      )
+    end
+
+    let(:query_variables) do
+      {
+        'baz' => 'unrelated',
+        'bazzz' => 'what we want'
+      }
+    end
+
+    it 'extracts the subquery correctly' do
+      expect(MockResolver).to receive(:call) do |_, _, ctx|
+        subq = described_class.new(ctx)
+
+        # Only sub-query relevant arguments are declared!
+        expect(subq.subquery_string.tr("\n", ' ').gsub(/\s+/, ' ')).to eq(
+          'GiraphQuery ($bazzz: String!) { argd(arg1: $bazzz) }'
+        )
+
+        # But all variables are passed on as is
+        expect(subq.variable_string).to eq(
+          '{"baz":"unrelated","bazzz":"what we want"}'
+        )
+
+        Struct.new(:argd).new(168)
+      end
+
+      expect(query_resolver)
+        .to receive(:resolver_method)
+        .and_return(Struct.new(:res).new(126))
+
+      resp = schema.execute(
+        query_string,
+        variables: query_variables,
+        context: query_context
+      )
+
+      expect(resp).to eq(
+        'data' => {
+          'remote' => { 'argd' => 10 },
+          'proxy' => { 'res' => 126 }
+        }
+      )
+    end
+  end
+
+  context 'given a valid mutation' do
+    let(:mutation_string) do
+      %(
+        mutation Test($baz: input_type!) {
+          remote {
+            update(input: $baz)
+          }
+        }
+      )
+    end
+
+    let(:mutation_variables) do
+      {
+        'baz' => { 'foo' => 'foo value', 'bar' => 42 }
+      }
+    end
+
+    it 'extracts the subquery correctly' do
+      expect(MockResolver).to receive(:call) do |_, _, ctx|
+        subq = described_class.new(ctx)
+
+        # Only sub-query relevant arguments are declared!
+        expect(subq.subquery_string.tr("\n", ' ').gsub(/\s+/, ' ')).to eq(
+          'GiraphQuery ($baz: input_type!) { update(input: $baz) }'
+        )
+
+        # But all variables are passed on as is
+        expect(subq.variable_string).to eq(
+          '{"baz":{"foo":"foo value","bar":42}}'
+        )
+
+        Struct.new(:argd).new(168)
+      end
+
+      expect(mutation_resolver)
+        .to receive(:update)
+        .and_return(126)
+
+      resp = schema.execute(
+        mutation_string,
+        variables: mutation_variables,
+        context: query_context
+      )
+
+      expect(resp).to eq('data' => {'remote' => { 'update' => 126 } })
+    end
+  end
+end

--- a/spec/giraph_spec.rb
+++ b/spec/giraph_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Giraph do
+  it 'has a version number' do
+    expect(Giraph::VERSION).not_to be nil
+  end
+end

--- a/spec/giraph_spec.rb
+++ b/spec/giraph_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe Giraph do
+  describe 'full integration' do
+    # TODO: A full, end-to-end integration test suite including:
+    # - Type definitions
+    # - Child: Schema declaration
+    # - Chile: Resolver declaration
+    # - Parent: Connected field declaration
+    # - Parent: Evaluator block
+    # - Request/Response
+  end
+
   it 'has a version number' do
     expect(Giraph::VERSION).not_to be nil
   end

--- a/spec/shared_definitions.rb
+++ b/spec/shared_definitions.rb
@@ -2,22 +2,38 @@ shared_context 'sample graphql structure' do
   class MockResolver; end
 
   let(:schema) do
-    GraphQL::Schema.new(
+    Giraph::Schema.new(
       query: query_root,
-      # mutation: mutation_root
+      query_resolver: query_resolver
     )
   end
 
   let(:query_root) do
+    TheType = GraphQL::ObjectType.define do
+      name 'TheType'
+
+      field :res, types.Int
+    end
+
     GraphQL::ObjectType.define do
       name 'Query'
 
       field :test do
-        type types.Int
+        type TheType
         argument :foo, types.String
         resolve MockResolver
       end
+
+      field :proxy do
+        type TheType
+        argument :foo, types.String
+        resolve Giraph::Resolver.new(:resolver_method)
+      end
     end
+  end
+
+  let(:query_resolver) do
+    double(:query_resolver)
   end
 
   let(:query_context) do
@@ -27,16 +43,12 @@ shared_context 'sample graphql structure' do
   end
 
   let(:query_string) do
-    'query Test($baz: String) { test(foo: $baz) }'
+    'query Test($baz: String) { test(foo: $baz) { res } }'
   end
 
   let(:query_variables) do
-    { 'baz' => 'foo value' }
-  end
-
-  let(:giraph_response) do
-    Giraph::Remote::Response[
-      test: 84
-    ]
+    {
+      'baz' => 'foo value'
+    }
   end
 end

--- a/spec/shared_definitions.rb
+++ b/spec/shared_definitions.rb
@@ -1,0 +1,42 @@
+shared_context 'sample graphql structure' do
+  class MockResolver; end
+
+  let(:schema) do
+    GraphQL::Schema.new(
+      query: query_root,
+      # mutation: mutation_root
+    )
+  end
+
+  let(:query_root) do
+    GraphQL::ObjectType.define do
+      name 'Query'
+
+      field :test do
+        type types.Int
+        argument :foo, types.String
+        resolve MockResolver
+      end
+    end
+  end
+
+  let(:query_context) do
+    {
+      bar: [1, 2]
+    }
+  end
+
+  let(:query_string) do
+    'query Test($baz: String) { test(foo: $baz) }'
+  end
+
+  let(:query_variables) do
+    { 'baz' => 'foo value' }
+  end
+
+  let(:giraph_response) do
+    Giraph::Remote::Response[
+      test: 84
+    ]
+  end
+end

--- a/spec/shared_definitions.rb
+++ b/spec/shared_definitions.rb
@@ -15,6 +15,14 @@ shared_context 'sample graphql structure' do
       name 'the_type'
 
       field :res, types.Int
+
+      field :argd do
+        type types.Int
+        argument :arg1, !types.String
+        resolve -> (o, a, c) {
+          10
+        }
+      end
     end
 
     GraphQL::ObjectType.define do
@@ -23,6 +31,11 @@ shared_context 'sample graphql structure' do
       field :test do
         type the_type
         argument :foo, types.String
+        resolve MockResolver
+      end
+
+      field :remote do
+        type the_type
         resolve MockResolver
       end
 
@@ -58,6 +71,11 @@ shared_context 'sample graphql structure' do
       field :test do
         type mutation_type
         argument :foo, types.String
+        resolve MockResolver
+      end
+
+      field :remote do
+        type mutation_type
         resolve MockResolver
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'giraph'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'giraph'
+require 'shared_definitions'


### PR DESCRIPTION
@dstuebe @danhodge 

_Note: Specs are coming up presently, just wanted to get your eyes on the implementation first_

Apologies on dumping a many-file pull but most of this is Gem fluff. The magic mostly happens in:
- **`extensions/field.rb`**: What overrides the original `GraphQL::Field` class' `.resolve` method, allowing us to not call the real resolvers from parent and just resolve on already-resolved JSON response.
- **`remote/connector.rb`**: This is what recontructs a full GraphQL query from the field on parent. Once done, it sends the request over and parses/validates the response or raises if needed.
- **`remote/query.rb`**: Piece that allows us to connect any field on the parent to a remote GraphQL endpoint. With this resolver, the field resolves to a `Giraph::Response` object (that comes from the remote) which then gets passed down to the rest of the query sub-tree as usual. Every field within the subtree then auto-resolves based on this because of the `extensions/field.rb` patch.

Not so magical glue pieces:
- **`remote/response.rb`**: Nothing but a no-op subclass of vanilla `Hash`. This is passed in to the JSON parser as `object_class` when parsing the remote response, allowing a Giraph response to be easily differentiated from any other object/structure.
- **`resolver.rb`**: I bet there is a name for this pattern but this special object registers a method name which it then calls upon the query or mutation resolver (on the child service) depending on which operation type we're executing at that point. Allows us to untie the definition gem fully from the Graph owner.
- **`schema.rb`**: Subclass of the `GraphQL::Schema`, adding a couple new config fields such as `query_resolver` and `mutation_resolver`, that gets passed down to the query execution. Also extracts the special `giraph_root` field from `variables` hash (optionally passed from Giraph parent), and sets that as query root value. This allows root level fields to have access to some context from Giraph parent (in our case, we use this to pass along the store pretty url, but this can be used to pass down anything).

Rest is syntactic sugar, internal helpers and fluff.
